### PR TITLE
Fix NameError in error massage: global name 'filePath' is not defined

### DIFF
--- a/wwpdb/apps/ccmodule/io/ChemCompIo.py
+++ b/wwpdb/apps/ccmodule/io/ChemCompIo.py
@@ -183,7 +183,6 @@ class ChemCompReader(object):
         """
         try:
             ifh=open(filePath,'r')
-            ifh = open(filePath, "r")
             myBlockList=[]
             pRd=PdbxReader(ifh)
             pRd.read(myBlockList)


### PR DESCRIPTION
Minor fix on error prompt message